### PR TITLE
Enable smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["algorithms", "command-line-utilities"]
 keywords = ["solver", "satisfiability", "sat"]
 
 [dependencies]
+smallvec = { version = "1.6.1", optional = true }
 
 [lib]
 name="screwsat"
@@ -28,4 +29,5 @@ walkdir="2"
 debug = true
 
 [features]
+enable-smallvec=["smallvec"]
 unsafe=[]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,12 +48,17 @@ pub mod solver {
 
     pub type Clause = Vec<Lit>;
 
+    #[cfg(feature="enable-smallvec")]
+    type InnerClause = smallvec::SmallVec<[Lit; 4]>;
+    #[cfg(not(feature="enable-smallvec"))]
+    type InnerClause = Vec<Lit>;
+
     #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
-    struct CRef(Rc<RefCell<Clause>>);
-    type CWRef = Weak<RefCell<Clause>>;
+    struct CRef(Rc<RefCell<InnerClause>>);
+    type CWRef = Weak<RefCell<InnerClause>>;
     impl CRef {
         fn new(clause: Clause) -> CRef {
-            CRef(Rc::new(RefCell::new(clause)))
+            CRef(Rc::new(RefCell::new(clause.into())))
         }
     }
 


### PR DESCRIPTION
Using `smallvec` make the program faster slightly.
I chose 4 to the number of elements of `smallvec` but it is arbitrary.

```bash
hatoo@hatoo-XPS-13-9300:~/screwsat$ cargo build --features=unsafe --release && time target/release/screwsat cnf/sat/perils_in_parallel_sub_01.cnf > /dev/null 
    Finished release [optimized + debuginfo] target(s) in 0.00s

real	0m3.276s
user	0m3.164s
sys	0m0.112s
hatoo@hatoo-XPS-13-9300:~/screwsat$ cargo build --features=unsafe,enable-smallvec --release && time target/release/screwsat cnf/sat/perils_in_parallel_sub_01.cnf > /dev/null 
    Finished release [optimized + debuginfo] target(s) in 0.00s

real	0m2.982s
user	0m2.886s
sys	0m0.096s
```